### PR TITLE
Fix: tt init dependence on config file

### DIFF
--- a/tt
+++ b/tt
@@ -1593,6 +1593,7 @@ Parses the arguments and calls the appropriate functions.
 
 if len(sys.argv) == 2 and sys.argv[1].lower() == "init":
     init()
+    sys.exit(0)
 elif len(sys.argv) <= 1:
     status()
     sys.exit(0)
@@ -1642,7 +1643,6 @@ elif cmd == "reset":
     reset_tracking()
 elif cmd == "comment":
     add_comment()
-
 
 else:
     usage()

--- a/tt
+++ b/tt
@@ -617,7 +617,7 @@ def init():
                         }
                     },
                 "log": [],
-                },
+                }
 
         # ... and write it to data file
         save(data, "Initialized new data file")
@@ -1591,15 +1591,15 @@ def show(limit = 10):
 Parses the arguments and calls the appropriate functions.
 """
 
-if len(sys.argv) <= 1:
+if len(sys.argv) == 2 and sys.argv[1].lower() == "init":
+    init()
+elif len(sys.argv) <= 1:
     status()
     sys.exit(0)
 
 cmd = parse_command(sys.argv[1].lower())
 
-if cmd == "init":
-    init()
-elif cmd == "status":
+if cmd == "status":
     status()
 elif cmd == "log":
     print_log()


### PR DESCRIPTION
Fixes #15 

Change Summary

* Do a singular check for the init arg prior to anything else
* Remove the check for the init arg in the set of elif's (is now covered first)
* Remove the ',' that follows the default config dict in init()
  * This was causing issues and causing complaints about dict being a tuple

NB: After this patch the first run of another command mentions that the config has been upgraded to v5?
```
cj@SableSlim /m/m/p/tt (master)> python3 tt add work
Converted data file format from version 4 to version 5
```

### Patched behaviour

(For comparison with #15 )
```
cj@SableSlim /tmp> git clone https://github.com/cavejay/tt.git tt-cavejay
Cloning into 'tt-cavejay'...
remote: Enumerating objects: 6, done.
remote: Counting objects: 100% (6/6), done.
remote: Compressing objects: 100% (5/5), done.
remote: Total 371 (delta 1), reused 5 (delta 1), pack-reused 365
Receiving objects: 100% (371/371), 105.79 KiB | 0 bytes/s, done.
Resolving deltas: 100% (142/142), done.
Checking connectivity... done.
cj@SableSlim /tmp> cd tt-cavejay/
cj@SableSlim /t/tt-cavejay (master)> python3 tt init
Initializing new data file /home/cj/.tt.json
cj@SableSlim /t/tt-cavejay (master)> python3 tt add project
Converted data file format from version 4 to version 5
Created project 1: "project"
```